### PR TITLE
Gulpfile.js: fix corrupt PNG image files in dist/images/

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -18,7 +18,7 @@ function copyAllFiles() {
         .src([
             'src/**/*.*',
             '!src/**/*.js',
-        ])
+        ],{encoding: false})
         .pipe(gulp.dest('./dist/'));
 }
 


### PR DESCRIPTION
As reported at https://github.com/TabCarousel/TabCarousel/issues/75 the PNG image files in dist/images/ are corrupted when building with Gulp version 5